### PR TITLE
Elo calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ pool of matches:
 python -m zero_sum_eval.main --pool -c configs/pool/chess.yaml
 ```
 
+### Calculation ratings
+
+```
+python -m zero_sum_eval.main --calculate-ratings -c configs/chess.yaml
+```
+
 ## Games
 
 ZeroSumEval currently supports the following games:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "chess>=1.9.0",
     "stockfish>=3.28.0",
     "datasets>=2.12.0",
+
+    # Analysis dependencies
+    "scikit-learn>=1.0.0",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -41,10 +44,6 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-runner>=6.0.0"
-]
-
-analysis = [
-    "scikit-learn>=1.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ analysis = [
 ]
 
 [project.scripts]
-zse = "zero_sum_eval.main:cli_run"
+zseval = "zero_sum_eval.main:cli_run"
 
 [project.urls]
 "Homepage" = "https://github.com/haidark/ZeroSumEval/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dev = [
     "pytest-runner>=6.0.0"
 ]
 
+analysis = [
+    "scikit-learn>=1.0.0",
+]
+
 [project.scripts]
 zse = "zero_sum_eval.main:cli_run"
 

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 from unittest.mock import MagicMock
 from zero_sum_eval.game_state import GameState, Action, PlayerDefinition
 from zero_sum_eval.player import Player
@@ -30,16 +31,15 @@ class TestGameState(GameState):
         return {"player1": 0, "player2": 0}
     
     def update_game(self, move):
+        # simulate an update taking time to test time logging
+        time.sleep(0.001)
         pass
     
     def is_over(self):
         return False
     
     def get_next_action(self):
-        return Action("test_action", self.players["player1"])
-    
-    def player_inputs(self):
-        return {}
+        return Action(name="test_action", player_key="player1", inputs={})
     
     def player_definitions(self):
         return [
@@ -76,9 +76,21 @@ def test_game_state_logging(mock_player):
     # Test that moves are logged
     class TestMove:
         value = "test_move"
-        trace = type('obj', (object,), {'toDict': lambda self: {}})()
+        class MockTrace:
+            def toDict(self):
+                return {}
+        trace = MockTrace()
     
     game.update_game(TestMove())
     exported = game.export()
     assert "last_move" in exported
-    assert exported["last_move"] == "test_move" 
+    assert "last_trace" in exported
+    assert "next_action" in exported
+    assert "player_key" in exported
+    assert "time" in exported
+    assert exported["last_move"] == "test_move"
+    assert exported["last_trace"] == {}
+    assert exported["next_action"] == "test_action"
+    assert exported["player_key"] == "player1"
+    assert isinstance(exported["time"], float)
+    assert exported["time"] > 0

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -76,6 +76,7 @@ def test_game_state_logging(mock_player):
     # Test that moves are logged
     class TestMove:
         value = "test_move"
+        time = 0.1
         class MockTrace:
             def toDict(self):
                 return {}

--- a/tests/test_games/conftest.py
+++ b/tests/test_games/conftest.py
@@ -38,6 +38,7 @@ def mock_move():
         def __init__(self, value="test value"):
             self.value = value
             self.trace = type('obj', (object,), {'toDict': lambda self: {}})()
+            self.time = 0.1
     return MockMove
 
 @pytest.fixture

--- a/tests/test_games/test_debate.py
+++ b/tests/test_games/test_debate.py
@@ -3,14 +3,6 @@ from unittest.mock import MagicMock
 from zero_sum_eval.games.debate.debate_game import DebateGame
 from zero_sum_eval.games.debate.debate_player import FOR_KEY, AGAINST_KEY
 
-@pytest.fixture
-def mock_move():
-    """Common mock move with trace for testing."""
-    class MockMove:
-        def __init__(self, value="test value"):
-            self.value = value
-            self.trace = type('obj', (object,), {'toDict': lambda self: {}})()
-    return MockMove
 
 @pytest.fixture
 def base_player_config():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ import json
 
 from zero_sum_eval.main import cli_run
 
+
 class MockLM:
     def __init__(self, *args, **kwargs):
         self.model = kwargs.get('model', 'mock-model')
@@ -11,7 +12,7 @@ class MockLM:
             "temperature": 0.7,
             "max_tokens": 1000,
         }
-        
+
     def __call__(self, messages=None, prompt=None, **kwargs):
         # Handle both messages and prompt-based calls
         if messages is not None:
@@ -22,10 +23,10 @@ class MockLM:
             response = self._get_response(prompt)
         else:
             raise ValueError("Either messages or prompt must be provided")
-            
+
         # Return response as a JSON string
         return [json.dumps(response)]
-    
+
     def _get_response(self, input_text):
         # Return predetermined responses based on input
         if "GenerateQuestion" in input_text or "target" in input_text:
@@ -44,13 +45,14 @@ class MockLM:
             "question": "What is 2 plus 2?"
         }
 
+
 def test_complete_mathquiz_game(monkeypatch, cleanup_logging):
     """Test a complete mathquiz game from start to finish through the CLI."""
     # Create a temporary directory for outputs
     with tempfile.TemporaryDirectory(prefix="test_main") as temp_dir:
         # Mock the LLM to avoid API calls
         monkeypatch.setattr("dspy.LM", MockLM)
-        
+
         # Set up CLI arguments for a mathquiz game
         test_args = [
             'main.py',
@@ -62,7 +64,82 @@ def test_complete_mathquiz_game(monkeypatch, cleanup_logging):
             '--max_rounds', '3',         # Limit rounds
             '--max_player_attempts', '2'  # Limit retries
         ]
-        
+
         # Run the game
         with patch('sys.argv', test_args):
             cli_run()
+
+
+def test_pool_mode(monkeypatch):
+    """Test the pool mode."""
+    with tempfile.TemporaryDirectory(prefix="test_main") as temp_dir:
+        test_args = [
+            'main.py',
+            '-g', 'mathquiz',
+            "--models", "mock-model", "mock-model",
+            "--max_matches", "5",
+            "--max_rounds", "3",
+            "--max_player_attempts", "2",
+            "--bootstrap_rounds", "1",
+            "--output_dir", temp_dir,
+            "--pool"
+        ]
+
+        # Mock the LLM to avoid API calls
+        monkeypatch.setattr("dspy.LM", MockLM)
+
+        with patch('sys.argv', test_args):
+            cli_run()
+
+
+def test_pool_with_calculate_elos(monkeypatch):
+    """Test the calculate_elos function."""
+    with tempfile.TemporaryDirectory(prefix="test_main") as temp_dir:
+        test_args = [
+            'main.py',
+            '-g', 'mathquiz',
+            "--models", "mock-model", "mock-model",
+            "--max_matches", "5",
+            "--max_rounds", "3",
+            "--max_player_attempts", "2",
+            "--bootstrap_rounds", "1",
+            "--output_dir", temp_dir,
+            "--pool",
+            "--calculate_elos"
+        ]
+
+        # Mock the LLM to avoid API calls
+        monkeypatch.setattr("dspy.LM", MockLM)
+
+        with patch('sys.argv', test_args):
+            # Mock the calculate_elos function
+            with patch('zero_sum_eval.main.calculate_elos') as mock_calculate_elos:
+                # Configure the mock to return our mock results
+                mock_calculate_elos.return_value = {
+                    "mock-model": 1000, "mock-model-2": 500}
+
+                # Run the CLI again with the calculate_elos flag
+                cli_run()
+
+                # Verify calculate_elos was called
+                mock_calculate_elos.assert_called_once()
+
+
+def test_calculate_elos_with_no_pool(monkeypatch):
+    """Test the calculate_elos function with no pool."""
+    with tempfile.TemporaryDirectory(prefix="test_main") as temp_dir:
+        test_args = [
+            'main.py',
+            '-o', temp_dir,
+            '--calculate_elos'
+        ]
+
+        # Mock the LLM to avoid API calls
+        monkeypatch.setattr("dspy.LM", MockLM)
+
+        with patch('sys.argv', test_args):
+            with patch('zero_sum_eval.main.calculate_elos') as mock_calculate_elos:
+                cli_run()
+
+                # Verify calculate_elos was called
+                mock_calculate_elos.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 import tempfile
 from unittest.mock import patch
 import json
-
+import pandas as pd
 from zero_sum_eval.main import cli_run
 
 
@@ -115,8 +115,12 @@ def test_pool_with_calculate_ratings(monkeypatch):
             # Mock the calculate_ratings function
             with patch('zero_sum_eval.main.calculate_ratings') as mock_calculate_ratings:
                 # Configure the mock to return our mock results
-                mock_calculate_ratings.return_value = {
-                    "mock-model": 1000, "mock-model-2": 500}
+                mock_calculate_ratings.return_value = pd.DataFrame({
+                    "model": ["mock-model", "mock-model-2"],
+                    "rating": [1000, 500],
+                    "lower": [950, 450],
+                    "upper": [1050, 550]
+                })
 
                 # Run the CLI again with the calculate_ratings flag
                 cli_run()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -92,8 +92,8 @@ def test_pool_mode(monkeypatch):
             cli_run()
 
 
-def test_pool_with_calculate_elos(monkeypatch):
-    """Test the calculate_elos function."""
+def test_pool_with_calculate_ratings(monkeypatch):
+    """Test the calculate_ratings function."""
     with tempfile.TemporaryDirectory(prefix="test_main") as temp_dir:
         test_args = [
             'main.py',
@@ -105,41 +105,41 @@ def test_pool_with_calculate_elos(monkeypatch):
             "--bootstrap_rounds", "1",
             "--output_dir", temp_dir,
             "--pool",
-            "--calculate_elos"
+            "--calculate_ratings"
         ]
 
         # Mock the LLM to avoid API calls
         monkeypatch.setattr("dspy.LM", MockLM)
 
         with patch('sys.argv', test_args):
-            # Mock the calculate_elos function
-            with patch('zero_sum_eval.main.calculate_elos') as mock_calculate_elos:
+            # Mock the calculate_ratings function
+            with patch('zero_sum_eval.main.calculate_ratings') as mock_calculate_ratings:
                 # Configure the mock to return our mock results
-                mock_calculate_elos.return_value = {
+                mock_calculate_ratings.return_value = {
                     "mock-model": 1000, "mock-model-2": 500}
 
-                # Run the CLI again with the calculate_elos flag
+                # Run the CLI again with the calculate_ratings flag
                 cli_run()
 
-                # Verify calculate_elos was called
-                mock_calculate_elos.assert_called_once()
+                # Verify calculate_ratings was called
+                mock_calculate_ratings.assert_called_once()
 
 
-def test_calculate_elos_with_no_pool(monkeypatch):
-    """Test the calculate_elos function with no pool."""
+def test_calculate_ratings_with_no_pool(monkeypatch):
+    """Test the calculate_ratings function with no pool."""
     with tempfile.TemporaryDirectory(prefix="test_main") as temp_dir:
         test_args = [
             'main.py',
             '-o', temp_dir,
-            '--calculate_elos'
+            '--calculate_ratings'
         ]
 
         # Mock the LLM to avoid API calls
         monkeypatch.setattr("dspy.LM", MockLM)
 
         with patch('sys.argv', test_args):
-            with patch('zero_sum_eval.main.calculate_elos') as mock_calculate_elos:
+            with patch('zero_sum_eval.main.calculate_ratings') as mock_calculate_ratings:
                 cli_run()
 
-                # Verify calculate_elos was called
-                mock_calculate_elos.assert_called_once()
+                # Verify calculate_ratings was called
+                mock_calculate_ratings.assert_called_once()

--- a/tests/test_managers/conftest.py
+++ b/tests/test_managers/conftest.py
@@ -101,4 +101,5 @@ def mock_move():
         def __init__(self, value="test value"):
             self.value = value
             self.trace = type('obj', (object,), {'toDict': lambda self: {}})()
+            self.time = 0.1
     return MockMove 

--- a/tests/test_managers/test_game_manager.py
+++ b/tests/test_managers/test_game_manager.py
@@ -55,7 +55,7 @@ def test_game_manager_start(mock_writer, mock_context, mock_config, mock_game):
     result = manager.start(mock_game)
     
     # Verify game was played correctly
-    assert result == mock_game
+    assert result["game_state"] == mock_game
     assert mock_game.update_game.called
     assert mock_game.get_next_action.called
     assert mock_game.export.called
@@ -88,7 +88,7 @@ def test_game_manager_turn_handling(mock_writer, mock_context, mock_config, mock
     result = manager.start(mock_game)
     
     # Verify turn was handled correctly
-    next_action = result.get_next_action()
+    next_action = result["game_state"].get_next_action()
     assert next_action == mock_action
     assert next_action.name == "test_action"
     assert next_action.player.player_key == "test_player"

--- a/zero_sum_eval/calculate_ratings.py
+++ b/zero_sum_eval/calculate_ratings.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from tqdm import tqdm
-
+from sklearn.linear_model import LogisticRegression
 
 # Function from https://lmsys.org/blog/2023-12-07-leaderboard/
 def compute_mle_elo(
@@ -65,11 +65,6 @@ def compute_mle_elo(
     X = X[:cur_row]
     Y = Y[:cur_row]
 
-    try:
-        from sklearn.linear_model import LogisticRegression
-    except ImportError:
-        raise ImportError("scikit-learn is required to calculate ELOs. Please install it with `pip install zero-sum-eval[analysis]`.")
-
     lr = LogisticRegression(fit_intercept=False, penalty=None, tol=1e-6)
     lr.fit(X, Y, sample_weight=sample_weights)
     elo_scores = SCALE * lr.coef_[0] + INIT_RATING
@@ -116,7 +111,7 @@ def convert_matches_to_df(logs_path: str, max_player_attempts: int) -> pd.DataFr
     return matches_df
 
 
-def calculate_elos(logs_path: str, bootstrap_rounds: int, max_player_attempts: int) -> pd.DataFrame:
+def calculate_ratings(logs_path: str, bootstrap_rounds: int, max_player_attempts: int) -> pd.DataFrame:
     match_df = convert_matches_to_df(logs_path, max_player_attempts)
     np.random.seed(1)
     bootstrap_elo_lu = get_bootstrap_result(match_df, compute_mle_elo, bootstrap_rounds)
@@ -138,5 +133,5 @@ if __name__ == "__main__":
     parser.add_argument("--max-player-attempts", "-m", help="Maximum number of player attempts.", type=int, default=5)
     args = parser.parse_args()
 
-    elos = calculate_elos(logs_path=args.logs_path, bootstrap_rounds=args.bootstrap_rounds, max_player_attempts=args.max_player_attempts)
-    print(elos)
+    ratings = calculate_ratings(logs_path=args.logs_path, bootstrap_rounds=args.bootstrap_rounds, max_player_attempts=args.max_player_attempts)
+    print(ratings)

--- a/zero_sum_eval/game_state.py
+++ b/zero_sum_eval/game_state.py
@@ -5,6 +5,7 @@ import logging
 
 from abc import ABC, abstractmethod
 from copy import copy
+import time
 from typing import Dict, List
 
 from zero_sum_eval.type_definitions import ActionConfig, Action
@@ -141,15 +142,16 @@ class GameState(ABC):
         def move_logging_wrapper(fn):
             def wrapped(self, move: Move):
                 try:
+                    start_time = time.time()
                     new_state = fn(self, move)
                     if not self.log_moves:
                         return new_state
-                    self._log = {"last_move": move.value, "last_trace": move.trace.toDict() if move.trace else None}
+                    self._log = {"last_move": move.value, "last_trace": move.trace.toDict() if move.trace else None, "time": time.time() - start_time}
                     return new_state
                 except InvalidMoveError as e:
                     if not hasattr(self, '_log'):
                         self._log = {}
-                    self._log.update({"last_move": move.value, "last_trace": move.trace.toDict() if move.trace else None, "error": str(e)})
+                    self._log.update({"last_move": move.value, "last_trace": move.trace.toDict() if move.trace else None, "error": str(e), "time": time.time() - start_time})
                     raise
             return wrapped
         

--- a/zero_sum_eval/game_state.py
+++ b/zero_sum_eval/game_state.py
@@ -145,6 +145,7 @@ class GameState(ABC):
                 _log = {
                     "last_move": move.value,
                     "last_trace": move.trace.toDict() if move.trace else None,
+                    "last_move_time": move.time,
                     "next_action": next_action.name,
                     "player_key": next_action.player_key,
                 }
@@ -168,9 +169,8 @@ class GameState(ABC):
         def export_logging_wrapper(fn):
             def wrapped(self):
                 new_dict = fn(self)
-                if not self.log_moves:
-                    return new_dict
-                new_dict.update(self._log)
+                if self.log_moves:
+                    new_dict.update(self._log)
                 return new_dict
             return wrapped
         

--- a/zero_sum_eval/games/chess/chess_game.py
+++ b/zero_sum_eval/games/chess/chess_game.py
@@ -102,7 +102,6 @@ class ChessGame(GameState):
         return {
             'message': self.message,
             'board_state': self.board.fen(),
-            'next_action': self.get_next_action().name,
             'history': self.history,
             'scores': self.get_scores()
         }

--- a/zero_sum_eval/main.py
+++ b/zero_sum_eval/main.py
@@ -3,6 +3,7 @@ import logging
 
 from collections import defaultdict
 
+from zero_sum_eval.calculate_elo import calculate_elos
 from zero_sum_eval.managers.game_pool_manager import GamePoolManager
 from zero_sum_eval.registry import GAME_REGISTRY
 from zero_sum_eval.logging_utils import cleanup_logging, setup_logging
@@ -14,18 +15,21 @@ logger = logging.getLogger(__name__)
 def setup_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-c", "--config", type=str, default=None, help="Optional path to a YAML config file. This overwrites other arguments if passed.")
-    parser.add_argument("-g", "--game", type=str, default="chess")
+    parser.add_argument("-g", "--game", type=str, default=None)
     parser.add_argument("-o", "--output_dir", type=str, default='./zse_outputs', help="Output directory for logs and results.")
 
     parser.add_argument("-p", "--players", type=str, nargs="+", help='List of models to evaluate and their roles. (LiteLLM model names, for example, "white=openai/gpt-4o" or "black=openrouter/meta-llama/llama-3.3-70b-instruct")')
     parser.add_argument("--game_kwargs", type=str, nargs="+", default="", help="Arguments to pass to the game constructor as a string. For example, 'rebuttal_rounds=2', 'topics=topics.txt' for the debate game.")
     parser.add_argument("--max_rounds", type=int, default=100, help="Maximum number of rounds to play.")
     parser.add_argument("--max_player_attempts", type=int, default=5, help="Maximum number of attempts to generate a valid player move.")
-
     # Pool mode arguments
     parser.add_argument("--pool", action="store_true", help="Run a pool of matches instead of a single game.")
     parser.add_argument("-m", "--models", type=str, nargs="+", help="List of models to evaluate. (Only for pool mode)")
     parser.add_argument("--max_matches", type=int, default=10, help="Maximum number of matches to play. (Only for pool mode)")
+
+    # Calculate ELOs arguments
+    parser.add_argument("--calculate_elos", action="store_true", help="Calculate ELOs for the models.")
+    parser.add_argument("--bootstrap_rounds", type=int, default=100, help="Number of bootstrap rounds to calculate ELOs.")
 
     # TODO: Add Player arguments. It only works with the default players for now.
     return parser
@@ -84,7 +88,7 @@ def run_single_game(config):
         logger.info("Starting a new game")
         final_state = game_manager.start(game)
         logger.info(
-            f"\nGame over. Final state:\n{final_state.display()}"
+            f"\nGame over. Final state:\n{final_state['game_state'].display()}"
         )
     finally:
         # Clean up logging
@@ -109,20 +113,51 @@ def run_pool_matches(config):
 def cli_run():
     parser = setup_parser()
     args = parser.parse_args()
+
+    # If we are running a single game, we need to specify players
+    if args.game and not args.pool and not args.calculate_elos and args.players is None:
+        raise ValueError("Must specify players when running a single game.")
+    
+    # Determine if we are running any games
+    is_running_games = args.pool or args.game
+
+    # If we are not running any games and calculate_elos is True, we need to only calculate ELOs without running any games from the output directory
+    if not is_running_games and args.calculate_elos and args.output_dir:
+        elos = calculate_elos(
+            logs_path=args.output_dir,
+            bootstrap_rounds=args.bootstrap_rounds,
+            max_player_attempts=args.max_player_attempts
+        )
+        print(elos)
+        return
+
     if args.output_dir is None:
         args.output_dir = f"zse_outputs/{args.game}"
         if args.pool:
             args.output_dir += "_pool"
-    
+
     if args.config:
         config = read_config(args.config)
     else:
         config = config_from_args(args)
     logger.info(f"Running {args.game} with config:\n{config}")
+
+    # Run matches if pool mode is enabled
     if args.pool:
         run_pool_matches(config)
-    else:
+
+    # Calculate ELO ratings if requested
+    if args.calculate_elos:
+        elos = calculate_elos(
+            logs_path=args.output_dir,
+            bootstrap_rounds=args.bootstrap_rounds,
+            max_player_attempts=args.max_player_attempts
+        )
+        print(elos)
+    # Run single game if no other modes specified
+    elif not args.pool and not args.calculate_elos:
         run_single_game(config)
+    
 
 if __name__ == "__main__":
     cli_run()

--- a/zero_sum_eval/main.py
+++ b/zero_sum_eval/main.py
@@ -13,15 +13,41 @@ from zero_sum_eval.managers import GameManager
 logger = logging.getLogger(__name__)
 
 def setup_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    """
+    Set up and return the command-line argument parser.
+    
+    The script supports three main modes of operation:
+    1. Single game mode: Run a single game between specified players
+    2. Pool mode: Run multiple games between different models
+    3. ELO calculation mode: Calculate ELO ratings from existing game logs
+    
+    Returns:
+        argparse.ArgumentParser: The configured argument parser
+    """
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="""\
+This script supports three modes of operation:
+1. Single game mode: Run a single game between specified players
+   Example: zseval --game chess --players "white=openai/gpt-4o" "black=anthropic/claude-3-opus"
+   
+2. Pool mode: Run multiple games between different models and optionally calculate ELOs at the end
+   Example: zseval --game chess --pool --models "openai/gpt-4o" "anthropic/claude-3-opus" --max_matches 10
+
+   
+3. ELO calculation mode: Calculate ELO ratings from existing game logs without running any games
+   Example: zseval --calculate_elos --output_dir ./zse_outputs/chess_pool
+"""
+    )
     parser.add_argument("-c", "--config", type=str, default=None, help="Optional path to a YAML config file. This overwrites other arguments if passed.")
-    parser.add_argument("-g", "--game", type=str, default=None)
+    parser.add_argument("-g", "--game", type=str, default=None, help="The game to play (e.g., chess, debate, etc.)")
     parser.add_argument("-o", "--output_dir", type=str, default='./zse_outputs', help="Output directory for logs and results.")
 
     parser.add_argument("-p", "--players", type=str, nargs="+", help='List of models to evaluate and their roles. (LiteLLM model names, for example, "white=openai/gpt-4o" or "black=openrouter/meta-llama/llama-3.3-70b-instruct")')
     parser.add_argument("--game_kwargs", type=str, nargs="+", default="", help="Arguments to pass to the game constructor as a string. For example, 'rebuttal_rounds=2', 'topics=topics.txt' for the debate game.")
     parser.add_argument("--max_rounds", type=int, default=100, help="Maximum number of rounds to play.")
     parser.add_argument("--max_player_attempts", type=int, default=5, help="Maximum number of attempts to generate a valid player move.")
+    
     # Pool mode arguments
     parser.add_argument("--pool", action="store_true", help="Run a pool of matches instead of a single game.")
     parser.add_argument("-m", "--models", type=str, nargs="+", help="List of models to evaluate. (Only for pool mode)")
@@ -113,6 +139,10 @@ def run_pool_matches(config):
 def cli_run():
     parser = setup_parser()
     args = parser.parse_args()
+
+    if args.game is None and not args.calculate_elos:
+        parser.print_help()
+        return
 
     # If we are running a single game, we need to specify players
     if args.game and not args.pool and not args.calculate_elos and args.players is None:

--- a/zero_sum_eval/managers/game_manager.py
+++ b/zero_sum_eval/managers/game_manager.py
@@ -26,7 +26,7 @@ class GameManager:
         self.turns_log_file = os.path.join(output_dir, "turns.jsonl")
         self.player_attempts = defaultdict(int)
 
-    def start(self, game_state: GameState) -> GameState:
+    def start(self, game_state: GameState) -> Dict:
         """
         Start the game with the given state.
 
@@ -34,7 +34,7 @@ class GameManager:
             game_state (GameState): The initial state of the game.
 
         Returns:
-            GameState: The final state of the game after the game loop ends.
+            Dict: A dictionary containing the final game state, the list of turns, and the player attempts.
         """
         logger = getLogger()
         turns: List[Dict] = []
@@ -68,7 +68,11 @@ class GameManager:
             
         self._log_game_turns(turns)
         
-        return game_state
+        return {
+            "game_state": game_state,
+            "turns": turns,
+            "player_attempts": self.player_attempts,
+        }
 
     def _log_game_turns(self, turns):
         with jsonlines.open(self.turns_log_file, "w") as f:

--- a/zero_sum_eval/player.py
+++ b/zero_sum_eval/player.py
@@ -162,8 +162,3 @@ class PlayerDefinition:
     default_player_class: Type[Player]
     optional: bool = False
 
-
-class HumanPlayer(Player):
-    def make_move(self, game_state):
-        move = input(f"{game_state} enter your move: ")
-        return move.strip()

--- a/zero_sum_eval/type_definitions.py
+++ b/zero_sum_eval/type_definitions.py
@@ -17,6 +17,7 @@ class ActionConfig:
 class Move:
     value: str
     trace: Optional[Prediction] = None
+    time: Optional[float] = None
 
 @dataclass
 class Action:


### PR DESCRIPTION
Moved the logic of elo calculation into the library.

main.py now handles 3 modes:

1. Run a single game
2. Run a pool of games (with a new optional ```--calculate_elos``` flag that prints an elo calculation at the end of the pool run)
3. Calculate the elos from an output directory without running any games:
```python
zse --calculate_elos --output_dir <POOL_MATCHES_DIR>
```